### PR TITLE
fix invalid shape size error for fmnist DCGAN

### DIFF
--- a/demoloader/DCGAN.py
+++ b/demoloader/DCGAN.py
@@ -6,7 +6,7 @@ class Generator(nn.Module):
         self.ngpu = ngpu
         self.main = nn.Sequential(
             # input is Z, going into a convolution
-            nn.ConvTranspose2d( nz, ngf * 8, 4, 1, 0, bias=False),
+            nn.ConvTranspose2d(nz, ngf * 8, 4, 1, 0, bias=False),
             nn.BatchNorm2d(ngf * 8),
             nn.ReLU(True),
             # state size. (ngf*8) x 4 x 4
@@ -14,15 +14,15 @@ class Generator(nn.Module):
             nn.BatchNorm2d(ngf * 4),
             nn.ReLU(True),
             # state size. (ngf*4) x 8 x 8
-            nn.ConvTranspose2d( ngf * 4, ngf * 2, 4, 2, 1, bias=False),
+            nn.ConvTranspose2d(ngf * 4, ngf * 2, 4, 2, 1, bias=False),
             nn.BatchNorm2d(ngf * 2),
             nn.ReLU(True),
             # state size. (ngf*2) x 16 x 16
-            nn.ConvTranspose2d( ngf * 2, ngf, 4, 2, 1, bias=False),
+            nn.ConvTranspose2d(ngf * 2, ngf, 4, 2, 1, bias=False),
             nn.BatchNorm2d(ngf),
             nn.ReLU(True),
             # state size. (ngf) x 32 x 32
-            nn.ConvTranspose2d( ngf, nc, 4, 2, 1, bias=False),
+            nn.ConvTranspose2d(ngf, nc, 4, 2, 1, bias=False),
             nn.Tanh()
             # state size. (nc) x 64 x 64
         )
@@ -93,12 +93,12 @@ class FashionGenerator(nn.Module):
         )
 
     def forward(self, x):
-        x = x.view(-1,100)
+        x = x.view(-1, 100)
         x = self.input(x)
         x = self.hidden1(x)
         x = self.hidden2(x)
         x = self.output(x)
-        return x.reshape(-1,1,28,28)
+        return x.reshape(-1, 1, 64, 64)
 
 
 class FashionDiscriminator(nn.Module):
@@ -128,10 +128,9 @@ class FashionDiscriminator(nn.Module):
         )
 
     def forward(self, x):
-        x = x.reshape(-1,28*28)
+        x = x.reshape(-1, 64 * 64)
         x = self.input(x)
         x = self.hidden1(x)
         x = self.hidden2(x)
         x = self.output(x)
         return x
-


### PR DESCRIPTION
When I use the following command to train, I get an error
```
ML-Doctor/demo.py --attack_type 1 --dataset_name fmnist 
```
error msg:
```
Starting Training DCGAN...
<======================= Epoch 1 =======================>
Traceback (most recent call last):
  File "/Users/liuchao18/Desktop/AI/ML-Doctor/demo.py", line 250, in <module>
    main()
  File "/Users/liuchao18/Desktop/AI/ML-Doctor/demo.py", line 231, in main
    train_DCGAN(TARGET_PATH, device, shadow_test + shadow_train, dataset_name)
  File "/Users/liuchao18/Desktop/AI/ML-Doctor/demo.py", line 61, in train_DCGAN
    GAN.train()
  File "/Users/liuchao18/Desktop/AI/ML-Doctor/demoloader/train.py", line 258, in train
    fake = self.model_generator(noise)
  File "/Users/liuchao18/anaconda3/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1501, in _call_impl
    return forward_call(*args, **kwargs)
  File "/Users/liuchao18/Desktop/AI/ML-Doctor/demoloader/DCGAN.py", line 102, in forward
    return x.reshape(-1, 1, 28, 28)
RuntimeError: shape '[-1, 1, 28, 28]' is invalid for input of size 524288
```

I think the reason for the error is that when building the dataset, the get_model_dataset function in `dataloader.py` redefines the size of the fmnist data to 64*64.

```
dataset_name.lower() == "fmnist":
        num_classes = 10
        transform = transforms.Compose([
            transforms.Resize((64, 64)),
            transforms.ToTensor(),
            transforms.Normalize((0.1307,), (0.3081,))
        ])
```
So I offer this modification, but I'm not sure it's the correct fix.

Successfully run screenshot after repair:
![image](https://github.com/liuyugeng/ML-Doctor/assets/82093214/dfe01dc5-2d70-44e5-8d6f-2024d622e986)

