### PR TITLE
fix attrinf attack training error

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -20,13 +20,13 @@ def train_model(PATH, device, train_set, test_set, model, use_DP, noise, norm, d
         train_set, batch_size=64, shuffle=True, num_workers=2)
     test_loader = torch.utils.data.DataLoader(
         test_set, batch_size=64, shuffle=True, num_workers=2)
-    
+
     model = model_training(train_loader, test_loader, model, device, use_DP, noise, norm, delta)
     acc_train = 0
     acc_test = 0
 
     for i in range(100):
-        print("<======================= Epoch " + str(i+1) + " =======================>")
+        print("<======================= Epoch " + str(i + 1) + " =======================>")
         print("target training")
 
         acc_train = model.train()
@@ -43,6 +43,7 @@ def train_model(PATH, device, train_set, test_set, model, use_DP, noise, norm, d
 
     return acc_train, acc_test, overfitting
 
+
 def train_DCGAN(PATH, device, train_set, name):
     train_loader = torch.utils.data.DataLoader(
         train_set, batch_size=128, shuffle=True, num_workers=2)
@@ -57,12 +58,14 @@ def train_DCGAN(PATH, device, train_set, name):
     print("Starting Training DCGAN...")
     GAN = GAN_training(train_loader, D, G, device)
     for i in range(200):
-        print("<======================= Epoch " + str(i+1) + " =======================>")
+        print("<======================= Epoch " + str(i + 1) + " =======================>")
         GAN.train()
 
     GAN.saveModel(PATH + "_discriminator.pth", PATH + "_generator.pth")
 
-def test_meminf(PATH, device, num_classes, target_train, target_test, shadow_train, shadow_test, target_model, shadow_model, train_shadow, use_DP, noise, norm, delta, mode):
+
+def test_meminf(PATH, device, num_classes, target_train, target_test, shadow_train, shadow_test, target_model,
+                shadow_model, train_shadow, use_DP, noise, norm, delta, mode):
     batch_size = 64
     if train_shadow:
         shadow_trainloader = torch.utils.data.DataLoader(
@@ -72,46 +75,50 @@ def test_meminf(PATH, device, num_classes, target_train, target_test, shadow_tra
 
         loss = nn.CrossEntropyLoss()
         optimizer = optim.SGD(shadow_model.parameters(), lr=1e-2, momentum=0.9, weight_decay=5e-4)
-        train_shadow_model(PATH, device, shadow_model, shadow_trainloader, shadow_testloader, use_DP, noise, norm, loss, optimizer, delta)
+        train_shadow_model(PATH, device, shadow_model, shadow_trainloader, shadow_testloader, use_DP, noise, norm, loss,
+                           optimizer, delta)
     if mode == 0 or mode == 3:
         attack_trainloader, attack_testloader = get_attack_dataset_with_shadow(
             target_train, target_test, shadow_train, shadow_test, batch_size)
     else:
         attack_trainloader, attack_testloader = get_attack_dataset_without_shadow(target_train, target_test, batch_size)
 
-
-    #for white box
+    # for white box
     if mode == 2 or mode == 3:
         gradient_size = get_gradient_size(target_model)
         total = gradient_size[0][0] // 2 * gradient_size[0][1] // 2
 
     if mode == 0:
         attack_model = ShadowAttackModel(num_classes)
-        attack_mode0(PATH + "_target.pth", PATH + "_shadow.pth", PATH, device, attack_trainloader, attack_testloader, target_model, shadow_model, attack_model, 1, num_classes)
+        attack_mode0(PATH + "_target.pth", PATH + "_shadow.pth", PATH, device, attack_trainloader, attack_testloader,
+                     target_model, shadow_model, attack_model, 1, num_classes)
 
     elif mode == 1:
         attack_model = PartialAttackModel(num_classes)
-        attack_mode1(PATH + "_target.pth", PATH, device, attack_trainloader, attack_testloader, target_model, attack_model, 1, num_classes)
+        attack_mode1(PATH + "_target.pth", PATH, device, attack_trainloader, attack_testloader, target_model,
+                     attack_model, 1, num_classes)
 
     elif mode == 2:
         attack_model = WhiteBoxAttackModel(num_classes, total)
-        attack_mode2(PATH + "_target.pth", PATH, device, attack_trainloader, attack_testloader, target_model, attack_model, 1, num_classes)
+        attack_mode2(PATH + "_target.pth", PATH, device, attack_trainloader, attack_testloader, target_model,
+                     attack_model, 1, num_classes)
 
     elif mode == 3:
         attack_model = WhiteBoxAttackModel(num_classes, total)
-        attack_mode3(PATH + "_target.pth", PATH + "_shadow.pth", PATH, device, 
-            attack_trainloader, attack_testloader, target_model, shadow_model, attack_model, 1, num_classes)
+        attack_mode3(PATH + "_target.pth", PATH + "_shadow.pth", PATH, device,
+                     attack_trainloader, attack_testloader, target_model, shadow_model, attack_model, 1, num_classes)
     else:
         raise Exception("Wrong mode")
-    
+
     # attack_mode0(PATH + "_target.pth", PATH + "_shadow.pth", PATH, device, attack_trainloader, attack_testloader, target_model, shadow_model, attack_model, 1, num_classes)
     # attack_mode1(PATH + "_target.pth", PATH, device, attack_trainloader, attack_testloader, target_model, attack_model, 1, num_classes)
     # attack_mode2(PATH + "_target.pth", PATH, device, attack_trainloader, attack_testloader, target_model, attack_model, 1, num_classes)
-    
+
 
 def test_modinv(PATH, device, num_classes, target_train, target_model, name):
     size = (1,) + tuple(target_train[0][0].shape)
-    target_model, evaluation_model = load_data(PATH + "_target.pth", PATH + "_eval.pth", target_model, models.resnet18(num_classes=num_classes))
+    target_model, evaluation_model = load_data(PATH + "_target.pth", PATH + "_eval.pth", target_model,
+                                               models.resnet18(num_classes=num_classes))
 
     # CCS 15
     modinv_ccs = ccs_inversion(target_model, size, num_classes, 1, 3000, 100, 0.001, 0.003, device)
@@ -129,9 +136,10 @@ def test_modinv(PATH, device, num_classes, target_train, target_model, name):
 
     PATH_D = PATH + "_discriminator.pth"
     PATH_G = PATH + "_generator.pth"
-    
+
     D, G, iden = prepare_GAN(name, D, G, PATH_D, PATH_G)
     modinv_revealer = revealer_inversion(G, D, target_model, evaluation_model, iden, device)
+
 
 def test_attrinf(PATH, device, num_classes, target_train, target_test, target_model):
     attack_length = int(0.5 * len(target_train))
@@ -147,7 +155,9 @@ def test_attrinf(PATH, device, num_classes, target_train, target_test, target_mo
 
     image_size = [1] + list(target_train[0][0].shape)
     train_attack_model(
-        PATH + "_target.pth", PATH, num_classes[1], device, target_model, attack_trainloader, attack_testloader, image_size)
+        PATH + "_target.pth", PATH, num_classes, device, target_model, attack_trainloader, attack_testloader,
+        image_size)
+
 
 def test_modsteal(PATH, device, train_set, test_set, target_model, attack_model):
     train_loader = torch.utils.data.DataLoader(
@@ -159,20 +169,22 @@ def test_modsteal(PATH, device, train_set, test_set, target_model, attack_model)
     optimizer = optim.SGD(attack_model.parameters(), lr=0.01, momentum=0.9)
 
     attacking = train_steal_model(
-        train_loader, test_loader, target_model, attack_model, PATH + "_target.pth", PATH + "_modsteal.pth", device, 64, loss, optimizer)
+        train_loader, test_loader, target_model, attack_model, PATH + "_target.pth", PATH + "_modsteal.pth", device, 64,
+        loss, optimizer)
 
     for i in range(100):
-        print("[Epoch %d/%d] attack training"%((i+1), 100))
+        print("[Epoch %d/%d] attack training" % ((i + 1), 100))
         attacking.train_with_same_distribution()
-    
+
     print("Finished training!!!")
     attacking.saveModel()
     acc_test, agreement_test = attacking.test()
-    print("Saved Target Model!!!\nstolen test acc = %.3f, stolen test agreement = %.3f\n"%(acc_test, agreement_test))
+    print("Saved Target Model!!!\nstolen test acc = %.3f, stolen test agreement = %.3f\n" % (acc_test, agreement_test))
+
 
 def str_to_bool(string):
     if isinstance(string, bool):
-       return string
+        return string
     if string.lower() in ('yes', 'true', 't', 'y', '1'):
         return True
     elif string.lower() in ('no', 'false', 'f', 'n', '0'):
@@ -180,24 +192,27 @@ def str_to_bool(string):
     else:
         raise argparse.ArgumentTypeError('Boolean value expected.')
 
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('-g', '--gpu', type=str, default="0")
-    parser.add_argument('-a', '--attributes', type=str, default="race", help="For attrinf, two attributes should be in format x_y e.g. race_gender")
+    parser.add_argument('-a', '--attributes', type=str, default="race",
+                        help="For attrinf, two attributes should be in format x_y e.g. race_gender")
     parser.add_argument('-dn', '--dataset_name', type=str, default="UTKFace")
     parser.add_argument('-at', '--attack_type', type=int, default=0)
     parser.add_argument('-tm', '--train_model', action='store_true')
     parser.add_argument('-ts', '--train_shadow', action='store_true')
-    parser.add_argument('-ud', '--use_DP', action='store_true',)
+    parser.add_argument('-ud', '--use_DP', action='store_true', )
     parser.add_argument('-ne', '--noise', type=float, default=1.3)
     parser.add_argument('-nm', '--norm', type=float, default=1.5)
     parser.add_argument('-d', '--delta', type=float, default=1e-5)
     parser.add_argument('-m', '--mode', type=int, default=0)
-    
+
     args = parser.parse_args()
 
     os.environ["CUDA_VISIBLE_DEVICES"] = args.gpu
     device = torch.device("cuda:0")
+    #device = torch.device("mps")  # osx arm64 gpu
 
     dataset_name = args.dataset_name
     attr = args.attributes
@@ -216,14 +231,16 @@ def main():
         os.makedirs(TARGET_ROOT)
     TARGET_PATH = TARGET_ROOT + dataset_name
 
-    num_classes, target_train, target_test, shadow_train, shadow_test, target_model, shadow_model = prepare_dataset(dataset_name, attr, root)
+    num_classes, target_train, target_test, shadow_train, shadow_test, target_model, shadow_model = prepare_dataset(
+        dataset_name, attr, root)
 
     if args.train_model:
         train_model(TARGET_PATH, device, target_train, target_test, target_model, use_DP, noise, norm, delta)
 
     # membership inference
     if args.attack_type == 0:
-        test_meminf(TARGET_PATH, device, num_classes, target_train, target_test, shadow_train, shadow_test, target_model, shadow_model, train_shadow, use_DP, noise, norm, delta, mode)
+        test_meminf(TARGET_PATH, device, num_classes, target_train, target_test, shadow_train, shadow_test,
+                    target_model, shadow_model, train_shadow, use_DP, noise, norm, delta, mode)
 
     # model inversion
     elif args.attack_type == 1:
@@ -236,15 +253,14 @@ def main():
 
     # model stealing
     elif args.attack_type == 3:
-        test_modsteal(TARGET_PATH, device, shadow_train+shadow_test, target_test, target_model, shadow_model)
+        test_modsteal(TARGET_PATH, device, shadow_train + shadow_test, target_test, target_model, shadow_model)
 
     else:
         sys.exit("we have not supported this mode yet! 0c0")
 
-
     # target_model = models.resnet18(num_classes=num_classes)
     # train_model(TARGET_PATH, device, target_train + shadow_train, target_test + shadow_test, target_model)
-    
+
+
 if __name__ == "__main__":
     main()
-    

--- a/demo.py
+++ b/demo.py
@@ -249,6 +249,9 @@ def main():
 
     # attribut inference
     elif args.attack_type == 2:
+        # check num_classes type , redefine the num_classes
+        if not isinstance(num_classes, int):
+            num_classes = num_classes[1]
         test_attrinf(TARGET_PATH, device, num_classes, target_train, target_test, target_model)
 
     # model stealing

--- a/demoloader/DCGAN.py
+++ b/demoloader/DCGAN.py
@@ -1,12 +1,13 @@
 import torch.nn as nn
 
+
 class Generator(nn.Module):
     def __init__(self, ngpu=1, nc=3, nz=100, ngf=64):
         super(Generator, self).__init__()
         self.ngpu = ngpu
         self.main = nn.Sequential(
             # input is Z, going into a convolution
-            nn.ConvTranspose2d( nz, ngf * 8, 4, 1, 0, bias=False),
+            nn.ConvTranspose2d(nz, ngf * 8, 4, 1, 0, bias=False),
             nn.BatchNorm2d(ngf * 8),
             nn.ReLU(True),
             # state size. (ngf*8) x 4 x 4
@@ -14,15 +15,15 @@ class Generator(nn.Module):
             nn.BatchNorm2d(ngf * 4),
             nn.ReLU(True),
             # state size. (ngf*4) x 8 x 8
-            nn.ConvTranspose2d( ngf * 4, ngf * 2, 4, 2, 1, bias=False),
+            nn.ConvTranspose2d(ngf * 4, ngf * 2, 4, 2, 1, bias=False),
             nn.BatchNorm2d(ngf * 2),
             nn.ReLU(True),
             # state size. (ngf*2) x 16 x 16
-            nn.ConvTranspose2d( ngf * 2, ngf, 4, 2, 1, bias=False),
+            nn.ConvTranspose2d(ngf * 2, ngf, 4, 2, 1, bias=False),
             nn.BatchNorm2d(ngf),
             nn.ReLU(True),
             # state size. (ngf) x 32 x 32
-            nn.ConvTranspose2d( ngf, nc, 4, 2, 1, bias=False),
+            nn.ConvTranspose2d(ngf, nc, 4, 2, 1, bias=False),
             nn.Tanh()
             # state size. (nc) x 64 x 64
         )
@@ -93,12 +94,12 @@ class FashionGenerator(nn.Module):
         )
 
     def forward(self, x):
-        x = x.view(-1,100)
+        x = x.view(-1, 100)
         x = self.input(x)
         x = self.hidden1(x)
         x = self.hidden2(x)
         x = self.output(x)
-        return x.reshape(-1,1,28,28)
+        return x.reshape(-1, 1, 64, 64)
 
 
 class FashionDiscriminator(nn.Module):
@@ -128,10 +129,9 @@ class FashionDiscriminator(nn.Module):
         )
 
     def forward(self, x):
-        x = x.reshape(-1,28*28)
+        x = x.reshape(-1, 64 * 64)
         x = self.input(x)
         x = self.hidden1(x)
         x = self.hidden2(x)
         x = self.output(x)
         return x
-


### PR DESCRIPTION
command:
```
ML-Doctor/demo.py --attack_type 2 --dataset_name fmnist 
```
when i try to train attrinf module, i got some errors:

1. num_classes error  `demo.py` line 150
```
train_attack_model(
        PATH + "_target.pth", PATH, num_classes[1], device, target_model, attack_trainloader, attack_testloader, image_size)
```
num_classes type is int, But here is using num_classes[1].

2. enumerate member error `attrinf.py` line 75 ,line 127
```
for batch_idx, (inputs, [_, targets]) in enumerate(self.attack_trainloader)
...
for inputs, [_, targets] in self.attack_testloader:
```

When I test and analyze against other files , `attack_testloader` or `enumerate(attack_testloader)` members are  (inputs, targets).

I found that when the dataset is utkface, celeba, numclass type is list. So the type checker is added under this attack mode.
After modification, it can run normally, but I'm not sure if this is the correct way to modify.

Run the screenshot after modification:
![image](https://github.com/liuyugeng/ML-Doctor/assets/82093214/8fe95074-dcde-4abb-b715-28fed182bab7)

